### PR TITLE
Add init subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Cargo.lock
 # End of https://www.toptal.com/developers/gitignore/api/rust
 
 node_modules
+
+dump

--- a/coral-cli/Cargo.toml
+++ b/coral-cli/Cargo.toml
@@ -3,7 +3,8 @@ name = "coral-cli"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "3.1.12", features = ["derive"] }
+coral = { path = '../coral' }
+trycmd = "0.13.3"

--- a/coral-cli/src/main.rs
+++ b/coral-cli/src/main.rs
@@ -1,22 +1,29 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
-/// Simple program to greet a person
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author = "Chris Boyce, Cameron Fraser", version = "0.1", about, long_about = None)]
 struct Args {
-    /// Name of the person to greet
-    #[clap(short, long)]
-    name: String,
+    #[clap(subcommand)]
+    action: Action,
+}
 
-    /// Number of times to greet
-    #[clap(short, long, default_value_t = 1)]
-    count: u8,
+#[derive(Subcommand, Debug)]
+enum Action {
+    /// Initialize coral
+    Init {
+        #[clap(short, long, forbid_empty_values = true, required = false)]
+        /// Location of directory to initialize in if different from cwd
+        dir: Option<String>,
+    },
 }
 
 fn main() {
     let args = Args::parse();
 
-    for _ in 0..args.count {
-        println!("Hello {}!", args.name)
+    match args.action {
+        Action::Init { dir } => match dir {
+            Some(d) => println!("dir provided at {}", d),
+            None => println!("No dir provided"),
+        },
     }
 }

--- a/coral-cli/tests/cli_tests.rs
+++ b/coral-cli/tests/cli_tests.rs
@@ -1,0 +1,4 @@
+#[test]
+fn cli_tests() {
+    trycmd::TestCases::new().case("tests/cmd/*.trycmd");
+}

--- a/coral-cli/tests/cmd/init.trycmd
+++ b/coral-cli/tests/cmd/init.trycmd
@@ -1,0 +1,13 @@
+Basic init:
+```
+$ coral-cli init
+No dir provided
+
+```
+
+Init with path:
+```
+$ coral-cli init -d /usr/local
+dir provided at /usr/local
+
+```

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+test-cli:
+    cargo test -p coral-cli
+
+update-cli-snapshots:
+    TRYCMD=overwrite cargo test -p coral-cli --test cli_tests


### PR DESCRIPTION
This PR adds the init subcommand that currently doesn't do anything, trycmd for testing, and a justfile for running tests and replacing snapshots